### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Url.php
+++ b/lib/Horde/Url.php
@@ -266,7 +266,7 @@ class Horde_Url
             ? $this->url
             : parse_url($this->url, PHP_URL_PATH);
 
-        if (strlen($this->pathInfo)) {
+        if (strlen(is_null($this->pathInfo) ? "" : $this->pathInfo)) {
             $url = rtrim($url, '/') . '/';
             if ($raw) {
                 $url .= $this->pathInfo;
@@ -303,7 +303,7 @@ class Horde_Url
                     }
                 } else {
                     $params[] = rawurlencode($p) .
-                        (strlen($v) ? ('=' . rawurlencode($v)) : '');
+                        (strlen(is_null($v) ? "" : $v) ? ('=' . rawurlencode($v)) : '');
                 }
             }
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Url/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Url/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Url Unut Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Url/AddTest.php
+++ b/test/Horde/Url/AddTest.php
@@ -7,7 +7,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Url_AddTest extends PHPUnit_Framework_TestCase
+class Horde_Url_AddTest extends Horde_Test_Case
 {
     public function testAddSimple()
     {

--- a/test/Horde/Url/CallbackTest.php
+++ b/test/Horde/Url/CallbackTest.php
@@ -7,7 +7,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Url_CallbackTest extends PHPUnit_Framework_TestCase
+class Horde_Url_CallbackTest extends Horde_Test_Case
 {
     public function testRemoveRaw()
     {

--- a/test/Horde/Url/ConstructorTest.php
+++ b/test/Horde/Url/ConstructorTest.php
@@ -7,7 +7,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Url_ConstructorTest extends PHPUnit_Framework_TestCase
+class Horde_Url_ConstructorTest extends Horde_Test_Case
 {
     public function testCopyAllParamsFromOriginal()
     {

--- a/test/Horde/Url/LinkTest.php
+++ b/test/Horde/Url/LinkTest.php
@@ -7,7 +7,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Url_LinkTest extends PHPUnit_Framework_TestCase
+class Horde_Url_LinkTest extends Horde_Test_Case
 {
     public function testLink()
     {

--- a/test/Horde/Url/RawTest.php
+++ b/test/Horde/Url/RawTest.php
@@ -7,7 +7,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Url_RawTest extends PHPUnit_Framework_TestCase
+class Horde_Url_RawTest extends Horde_Test_Case
 {
     public function testFromString()
     {

--- a/test/Horde/Url/RedirectTest.php
+++ b/test/Horde/Url/RedirectTest.php
@@ -7,10 +7,11 @@
  * @subpackage UnitTests
  */
 
-class Horde_Url_RedirectTest extends PHPUnit_Framework_TestCase
+class Horde_Url_RedirectTest extends Horde_Test_Case
 {
     public function testEmptyRedirect()
     {
+        $this->expectNotToPerformAssertions();
         $url = new Horde_Url('');
 
         try {

--- a/test/Horde/Url/RemoveTest.php
+++ b/test/Horde/Url/RemoveTest.php
@@ -7,7 +7,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Url_RemoveTest extends PHPUnit_Framework_TestCase
+class Horde_Url_RemoveTest extends Horde_Test_Case
 {
     public function testRemoveRaw()
     {

--- a/test/Horde/Url/TostringTest.php
+++ b/test/Horde/Url/TostringTest.php
@@ -7,7 +7,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Url_TostringTest extends PHPUnit_Framework_TestCase
+class Horde_Url_TostringTest extends Horde_Test_Case
 {
     public function testFullUrl()
     {

--- a/test/Horde/Url/UrlDataTest.php
+++ b/test/Horde/Url/UrlDataTest.php
@@ -24,7 +24,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Url_UrlDataTest extends PHPUnit_Framework_TestCase
+class Horde_Url_UrlDataTest extends Horde_Test_Case
 {
     public function testParsingDataUrl()
     {


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-url/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: 1011_php8.1.patch https://salsa.debian.org/horde-team/php-horde-url/-/blob/debian-sid/debian/patches/1011_php8.1.patch
