### PR TITLE
Reimplement parameters encoding in Horde_Url's toString() method  to restore the intended functionality

### DIFF
--- a/lib/Horde/Url.php
+++ b/lib/Horde/Url.php
@@ -264,16 +264,10 @@ class Horde_Url
             }
         }
 
-        if ($params = $this->parameters) {
-            foreach ($params as $p => &$v) {
-                // TODO: Investigate if it should be done for all (or some) other objects
-                if ($v instanceof Horde_Url) {
-                    $v = strval($v);
-                }
-            }
-            unset($v);
-
-            $url .= '?' . http_build_query($params, "", $raw ? '&' : '&amp;');
+        if ($source = $this->parameters) {
+            $params = [];
+            self::encodeParameters($source, '', $params);
+            $url .= '?' . implode($raw ? '&' : '&amp;', $params);
         }
 
         if ($this->anchor) {
@@ -281,6 +275,38 @@ class Horde_Url
         }
 
         return $url;
+    }
+
+    protected static function encodeParameters($source, $prefix, &$params)
+    {
+        $index = 0;
+
+        foreach ($source as $p => $v) {
+            if (strlen($prefix)) { 
+                if ($index >= 0 && $p !== $index) {
+                    $index = -1;
+                }
+                if ($index >= 0) {
+                    $p = '';
+                    ++$index;
+                } else {
+                   $p = rawurlencode($p);
+                }
+                $p = $prefix . '[' . $p . ']';
+            } else {
+               $p = rawurlencode($p);
+            }
+
+            if (is_array($v)) {
+                self::encodeParameters($v, $p, $params);
+            } else {
+                $v = (string) $v;
+                if (strlen($v)) {
+                    $p .= '=' . rawurlencode($v);
+                }
+                $params[] = $p;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Highlights:
 * Process nested arrays recursively
 * Convert other values by casting to `(string)` (this takes care of `Horde_Url`)
 * Do not output consecutive numeric indexes in arrays
 * Do not skip parameters with empty values
 * Do not encode `[` and `]`

This also fixes the test failures mentioned in #2.

With this PR, instances of classes without `__toString()` will not be encoded the way `http_build_query` would encode them, but this is how it was before 523d5e5, anyway.

More tests should be added, specifically to test nested arrays (possible with `Horde_Url`), e.g.
```php
    $url->add('x', [ 'abc', 'def', [ 'k1' => 'v1', 'k2' => 'v2 '] ];
```